### PR TITLE
Ajouter un fichier pour gagner du temps dans le workflow

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,4 @@
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$
+^dev$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,6 +46,7 @@ Imports:
 Suggests: 
     gouvdown.fonts,
     pals,
+    pkgload,
     scales,
     sf,
     testthat,

--- a/dev/run_dev_html_gouv.R
+++ b/dev/run_dev_html_gouv.R
@@ -1,16 +1,17 @@
 ## Script pour les modifs en live
+local({
+  all_attached <- paste("package:", names(sessionInfo()$otherPkgs),
+                        sep = "")
+  try(suppressWarnings(lapply(all_attached,
+                              detach, character.only = TRUE, unload = TRUE)), silent = TRUE)
 
-all_attached <- paste("package:", names(sessionInfo()$otherPkgs),
-                      sep = "")
-try(suppressWarnings(lapply(all_attached,
-       detach, character.only = TRUE, unload = TRUE)), silent = TRUE)
+  pkgload::load_all()
 
-pkgload::load_all()
+  file_rmd <- system.file("rmarkdown", "templates", "gouvdown_html_document", "skeleton", "skeleton.Rmd", package = "gouvdown")
 
-file_rmd <- system.file("rmarkdown", "templates", "gouvdown_html_document", "skeleton", "skeleton.Rmd", package = "gouvdown")
-
-ok <- rmarkdown::render(
-  file_rmd,
-  output_format = gouvdown::html_gouv()
-)
-browseURL(ok)
+  ok <- rmarkdown::render(
+    file_rmd,
+    output_format = gouvdown::html_gouv()
+  )
+  browseURL(ok)
+})

--- a/dev/run_dev_html_gouv.R
+++ b/dev/run_dev_html_gouv.R
@@ -1,0 +1,16 @@
+## Script pour les modifs en live
+
+all_attached <- paste("package:", names(sessionInfo()$otherPkgs),
+                      sep = "")
+try(suppressWarnings(lapply(all_attached,
+       detach, character.only = TRUE, unload = TRUE)), silent = TRUE)
+
+pkgload::load_all()
+
+file_rmd <- system.file("rmarkdown", "templates", "gouvdown_html_document", "skeleton", "skeleton.Rmd", package = "gouvdown")
+
+ok <- rmarkdown::render(
+  file_rmd,
+  output_format = gouvdown::html_gouv()
+)
+browseURL(ok)


### PR DESCRIPTION
Bonjour, suite à une conversation avec Diane, voici une toute petite contribution pour faire gagner du temps en développement. 

Il y a un script dans un dossier dev qui reprend en partie l'idée des `run_dev` du package {golem}. Le but étant pour vous de pouvoir changer les ressources comme le css et de voir assez facilement les changements. 

Je n'ai fait ce travail que pour le `html_gouv`. Aussi pour le bookdown, il existe `bookdown::serve_book` qui permet le même fonctionnement que `infinite_moon_reader` du package {xaringan}. Ou vous pouvez aussi faire un `run_dev` pour le bookdown. 